### PR TITLE
Fix duplicate chest grants on app restart

### DIFF
--- a/App.js
+++ b/App.js
@@ -2804,7 +2804,18 @@ export default function App() {
           return;
         }
 
-        setXp(data.xp);
+        const xpValue = Number.isFinite(data.xp) ? data.xp : 0;
+        const hydratedLevel = lvl(xpValue);
+        if (hydratedLevel && Number.isFinite(hydratedLevel.l)) {
+          previousLevelRef.current = hydratedLevel.l;
+        } else {
+          const baselineLevel = lvl(0);
+          previousLevelRef.current = Number.isFinite(baselineLevel?.l)
+            ? baselineLevel.l
+            : null;
+        }
+
+        setXp(xpValue);
         setApps(data.apps);
         setGold(data.gold);
         setStreak(data.streak);


### PR DESCRIPTION
## Summary
- prevent the level-tracking ref from treating hydrated XP as fresh level-ups
- compute the hydrated level before applying persisted XP so that reopening the app does not award duplicate chests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77a2432ac832c813ac86f6f8ce992