### PR TITLE
Refactor shared utilities into dedicated modules

### DIFF
--- a/src/state/persistence/sanitizers.js
+++ b/src/state/persistence/sanitizers.js
@@ -1,0 +1,212 @@
+import { FOCUS_BASELINE } from '../../features/progression';
+
+export const parseFiniteNumber = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed.length) {
+      return null;
+    }
+    const numeric = Number(trimmed);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+};
+
+export const sanitizeArrayOfObjects = (input) => {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return input.reduce((acc, item) => {
+    if (item && typeof item === 'object') {
+      acc.push({ ...item });
+    }
+    return acc;
+  }, []);
+};
+
+export const sanitizeRecordOfArrays = (input) => {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+  const result = {};
+  Object.entries(input).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      result[key] = value.reduce((entries, entry) => {
+        if (entry && typeof entry === 'object') {
+          entries.push({ ...entry });
+        }
+        return entries;
+      }, []);
+    }
+  });
+  return result;
+};
+
+export const sanitizeRecordOfObjects = (input) => {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+  const result = {};
+  Object.entries(input).forEach(([key, value]) => {
+    if (value && typeof value === 'object') {
+      result[key] = { ...value };
+    }
+  });
+  return result;
+};
+
+export const sanitizePremiumProgress = (input) => {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+  const result = {};
+  Object.entries(input).forEach(([key, value]) => {
+    const numeric = parseFiniteNumber(value);
+    if (numeric != null) {
+      result[key] = Math.max(0, numeric);
+    }
+  });
+  return result;
+};
+
+export const sanitizeClaimedQuests = (input) => {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  const unique = new Set();
+  input.forEach((value) => {
+    if (value != null) {
+      unique.add(String(value));
+    }
+  });
+  return Array.from(unique);
+};
+
+export const sanitizeSprayDebuff = (input) => {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const activatedAt = parseFiniteNumber(input.activatedAt);
+  const expiresAt = parseFiniteNumber(input.expiresAt);
+  if (activatedAt == null && expiresAt == null) {
+    return null;
+  }
+  const result = {};
+  if (activatedAt != null) {
+    result.activatedAt = activatedAt;
+  }
+  if (expiresAt != null) {
+    result.expiresAt = expiresAt;
+  }
+  return result;
+};
+
+export const createDefaultQuestMeta = () => ({
+  lastDailyKey: '',
+  lastWeeklyKey: '',
+  lastAppVersion: '',
+});
+
+const createDefaultPersistedState = () => ({
+  xp: 0,
+  apps: 0,
+  gold: 0,
+  streak: 0,
+  focus: FOCUS_BASELINE,
+  activeEffects: [],
+  sprayDebuff: null,
+  applications: [],
+  claimedQuests: [],
+  manualLogs: {},
+  eventStates: {},
+  chests: [],
+  premiumProgress: {},
+  questMeta: createDefaultQuestMeta(),
+});
+
+export const sanitizeQuestMeta = (input) => {
+  const defaults = createDefaultQuestMeta();
+  if (!input || typeof input !== 'object') {
+    return { ...defaults };
+  }
+  const result = { ...defaults };
+  if (typeof input.lastDailyKey === 'string') {
+    result.lastDailyKey = input.lastDailyKey;
+  }
+  if (typeof input.lastWeeklyKey === 'string') {
+    result.lastWeeklyKey = input.lastWeeklyKey;
+  }
+  if (typeof input.lastAppVersion === 'string') {
+    result.lastAppVersion = input.lastAppVersion;
+  }
+  return result;
+};
+
+export const sanitizePersistedData = (candidate) => {
+  const defaults = createDefaultPersistedState();
+  const safe = candidate && typeof candidate === 'object' ? candidate : {};
+
+  const applications = sanitizeArrayOfObjects(safe.applications);
+  const activeEffects = sanitizeArrayOfObjects(safe.activeEffects);
+  const chests = sanitizeArrayOfObjects(safe.chests);
+  const manualLogs = sanitizeRecordOfArrays(safe.manualLogs);
+  const eventStates = sanitizeRecordOfObjects(safe.eventStates);
+  const premiumProgress = sanitizePremiumProgress(safe.premiumProgress);
+  const sprayDebuff = sanitizeSprayDebuff(safe.sprayDebuff);
+  const questMeta = sanitizeQuestMeta(safe.questMeta);
+
+  const xp = parseFiniteNumber(safe.xp);
+  const appsCount = parseFiniteNumber(safe.apps);
+  const gold = parseFiniteNumber(safe.gold);
+  const streak = parseFiniteNumber(safe.streak);
+  const focus = parseFiniteNumber(safe.focus);
+
+  return {
+    xp: xp != null ? Math.max(0, xp) : defaults.xp,
+    apps: appsCount != null ? Math.max(0, appsCount) : applications.length,
+    gold: gold != null ? Math.max(0, gold) : defaults.gold,
+    streak: streak != null ? Math.max(0, streak) : defaults.streak,
+    focus: focus != null ? Math.max(0, focus) : defaults.focus,
+    activeEffects,
+    sprayDebuff,
+    applications,
+    claimedQuests: sanitizeClaimedQuests(safe.claimedQuests),
+    manualLogs,
+    eventStates,
+    chests,
+    premiumProgress,
+    questMeta,
+  };
+};
+
+export const MIGRATIONS = {
+  1: (state) => sanitizePersistedData(state),
+};
+
+export const migratePersistedState = (payload, storageVersion = 1) => {
+  if (!payload || typeof payload !== 'object') {
+    return { version: storageVersion, data: sanitizePersistedData() };
+  }
+  const startingVersion = Number.isInteger(payload.version) ? payload.version : 0;
+  let currentVersion = startingVersion;
+  let currentState = payload.data && typeof payload.data === 'object' ? payload.data : {};
+
+  if (currentVersion > storageVersion) {
+    currentVersion = storageVersion;
+  }
+
+  while (currentVersion < storageVersion) {
+    const targetVersion = currentVersion + 1;
+    const migrate = MIGRATIONS[targetVersion];
+    if (typeof migrate === 'function') {
+      currentState = migrate(currentState);
+    }
+    currentVersion = targetVersion;
+  }
+
+  const sanitized = sanitizePersistedData(currentState);
+  return { version: storageVersion, data: sanitized };
+};

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,0 +1,48 @@
+export const hexToRgba = (hex, alpha) => {
+  if (!hex || typeof hex !== 'string' || !hex.startsWith('#')) {
+    return `rgba(148, 163, 184, ${alpha})`;
+  }
+  const sanitized = hex.replace('#', '');
+  const normalized =
+    sanitized.length === 3
+      ? sanitized
+          .split('')
+          .map((char) => char + char)
+          .join('')
+      : sanitized.slice(0, 6);
+  const bigint = parseInt(normalized, 16);
+  if (Number.isNaN(bigint)) {
+    return `rgba(148, 163, 184, ${alpha})`;
+  }
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+export const ensureOpaque = (color, fallback = '#fff') => {
+  if (!color || typeof color !== 'string') {
+    return fallback;
+  }
+  const normalized = color.replace(/\s+/g, '');
+  const rgbaMatch = normalized.match(/^rgba?\(([-\d.]+),([-\d.]+),([-\d.]+)(?:,([-\d.]+))?\)$/i);
+  if (rgbaMatch) {
+    const r = Math.round(Number(rgbaMatch[1]));
+    const g = Math.round(Number(rgbaMatch[2]));
+    const b = Math.round(Number(rgbaMatch[3]));
+    if ([r, g, b].every((value) => !Number.isNaN(value))) {
+      return `rgb(${r}, ${g}, ${b})`;
+    }
+  }
+  if (normalized.startsWith('#')) {
+    return color;
+  }
+  return fallback;
+};
+
+export const getGlassGradientColors = (colors) => [
+  hexToRgba(colors.sky, 0.35),
+  hexToRgba(colors.emerald, 0.35),
+];
+
+export const getGlassBorderColor = (colors) => hexToRgba(colors.sky, 0.45);

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,34 @@
+const pad = (value) => String(value).padStart(2, '0');
+
+export const formatGoldValue = (value) =>
+  Math.max(0, value).toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  });
+
+export const formatGold = (value) => `${formatGoldValue(value)}g`;
+
+export const formatEffectDuration = (seconds) => {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return null;
+  }
+  if (seconds >= 3600) {
+    const hours = Math.round(seconds / 3600);
+    return `${hours} hour${hours === 1 ? '' : 's'}`;
+  }
+  const minutes = Math.round(seconds / 60);
+  if (minutes >= 1) {
+    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+  const rounded = Math.round(seconds);
+  return `${rounded} second${rounded === 1 ? '' : 's'}`;
+};
+
+export const formatTime = (seconds) => {
+  const safeSeconds = Math.max(0, Math.floor(Number(seconds) || 0));
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const remainingSeconds = safeSeconds % 60;
+  return hours > 0
+    ? `${pad(hours)}:${pad(minutes)}:${pad(remainingSeconds)}`
+    : `${pad(minutes)}:${pad(remainingSeconds)}`;
+};

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,17 @@
+export const toTimestamp = (value) => {
+  if (value == null) {
+    return NaN;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : NaN;
+  }
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? time : NaN;
+  }
+  if (typeof value === 'string' && value.trim().length) {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? NaN : parsed;
+  }
+  return NaN;
+};


### PR DESCRIPTION
## Summary
- extract color helpers into src/utils/color and reuse them throughout App.js
- add shared formatters and time utilities for gold, timers, and timestamps
- centralize persistence sanitizers and migration helpers under src/state/persistence

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d78903ba88832ca19a719d89a78ca3