### PR TITLE
Refactor quest board UI into hooks and components

### DIFF
--- a/src/features/quests/components/QuestCard.js
+++ b/src/features/quests/components/QuestCard.js
@@ -1,0 +1,419 @@
+import { memo, useMemo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { hexToRgba } from '../../../utils/color';
+import { formatTime } from '../../../utils/formatters';
+import QuestStageList from './QuestStageList';
+
+const isQuestTrackable = (quest) => quest?.trackable === true;
+
+const QuestCardComponent = ({
+  quest,
+  colors,
+  currentTime,
+  makeRewardEntries,
+  getStageProgressSummary,
+  onClaim,
+  onAction,
+  onLogStage,
+  filledSurface,
+  questCardShadow,
+  isLast,
+}) => {
+  const trackable = isQuestTrackable(quest);
+  const progress = trackable ? quest?.progress ?? 0 : 0;
+  const goalValue = trackable ? quest?.goalValue ?? 0 : 0;
+  const claimed = quest?.claimed === true;
+  const claimable = quest?.claimable === true;
+  const percent = trackable
+    ? quest?.percent ?? (goalValue > 0 ? Math.min(100, (progress / goalValue) * 100) : 0)
+    : 0;
+  const questReward = quest?.claimReward || quest?.reward;
+  const rewardEntries = useMemo(() => makeRewardEntries?.(questReward) || [], [makeRewardEntries, questReward]);
+  const rewardBonuses = useMemo(() => {
+    const entries = [];
+    if (questReward?.effect) {
+      entries.push({ icon: 'auto-fix', color: colors.lilac, label: questReward.effect });
+    }
+    if (questReward?.cleanse) {
+      entries.push({ icon: 'broom', color: colors.sky, label: `Cleanse: ${questReward.cleanse}` });
+    }
+    return entries;
+  }, [questReward, colors]);
+
+  const tierSummary = useMemo(
+    () => (Array.isArray(quest?.tiers) ? getStageProgressSummary?.(quest.tiers) : null),
+    [quest?.tiers, getStageProgressSummary],
+  );
+
+  const isMilestoneChain = quest?.stageLabel === 'Milestone';
+  const milestoneSummary = useMemo(() => {
+    if (!isMilestoneChain || !Array.isArray(quest?.steps)) {
+      return null;
+    }
+    return getStageProgressSummary?.(quest.steps) ?? null;
+  }, [isMilestoneChain, quest?.steps, getStageProgressSummary]);
+
+  const showTaskStages = useMemo(() => {
+    if (!Array.isArray(quest?.steps) || !quest.steps.length) {
+      return false;
+    }
+    return !isMilestoneChain;
+  }, [quest?.steps, isMilestoneChain]);
+
+  const isEventQuest = quest?.type === 'event';
+  const remainingSeconds = useMemo(() => {
+    if (!isEventQuest || !Number.isFinite(quest?.expiresAt)) {
+      return null;
+    }
+    return Math.max(0, Math.ceil((quest.expiresAt - currentTime) / 1000));
+  }, [isEventQuest, quest?.expiresAt, currentTime]);
+  const timeRemainingLabel = remainingSeconds > 0 ? formatTime(remainingSeconds) : null;
+
+  const renderMetaRow = (icon, label, value, key) => {
+    if (!value) {
+      return null;
+    }
+    return (
+      <View key={key} style={styles.metaRow}>
+        <MaterialCommunityIcons name={icon} size={14} color={colors.sky} />
+        <Text style={[styles.metaLabel, { color: hexToRgba(colors.text, 0.7) }]}>{label}:</Text>
+        <Text style={[styles.metaValue, { color: colors.text }]}>{value}</Text>
+      </View>
+    );
+  };
+
+  const cardMargin = isLast ? 0 : 12;
+
+  return (
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: filledSurface,
+          borderColor: colors.surfaceBorder,
+          marginBottom: cardMargin,
+        },
+        questCardShadow,
+      ]}
+    >
+      <View style={styles.header}>
+        <View style={styles.titleGroup}>
+          <Text style={[styles.title, { color: colors.text }]}>{quest?.title}</Text>
+          {quest?.subtitle ? (
+            <Text style={[styles.subtitle, { color: hexToRgba(colors.text, 0.72) }]}>{quest.subtitle}</Text>
+          ) : null}
+        </View>
+        {rewardEntries.length ? (
+          <View style={styles.rewardMeta}>
+            {rewardEntries.map((entry, index) => (
+              <View key={`${quest?.id}-reward-${index}`} style={styles.rewardPill}>
+                <MaterialCommunityIcons name={entry.icon} size={14} color={entry.color} />
+                <Text style={[styles.rewardText, { color: colors.text }]}>{entry.label}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </View>
+
+      {Array.isArray(quest?.actions) && quest.actions.length ? (
+        <View style={styles.actionsRow}>
+          {quest.actions.map((action, actionIndex) => (
+            <TouchableOpacity
+              key={`${quest?.id}-action-${actionIndex}`}
+              onPress={() => onAction?.(action, quest)}
+              style={[styles.actionButton, { borderColor: colors.surfaceBorder, backgroundColor: colors.chipBg }]}
+              activeOpacity={0.85}
+            >
+              <MaterialCommunityIcons
+                name={action.icon || 'plus-circle-outline'}
+                size={14}
+                color={colors.sky}
+              />
+              <Text style={[styles.actionText, { color: colors.text }]}>{action.label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      ) : null}
+
+      {rewardBonuses.length ? (
+        <View style={styles.infoSection}>
+          <Text style={[styles.infoLabel, { color: colors.text }]}>Bonus</Text>
+          <View style={styles.bonusList}>
+            {rewardBonuses.map((bonus, index) => (
+              <View
+                key={`${quest?.id}-bonus-${index}`}
+                style={[styles.bonusPill, { borderColor: colors.surfaceBorder, backgroundColor: colors.chipBg }]}
+              >
+                <MaterialCommunityIcons name={bonus.icon} size={14} color={bonus.color} />
+                <Text style={[styles.bonusText, { color: colors.text }]}>{bonus.label}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      ) : null}
+
+      {Array.isArray(quest?.goals) && quest.goals.length ? (
+        <View style={styles.infoSection}>
+          {quest.goals.map((goal, goalIndex) => (
+            <Text key={`${quest?.id}-goal-${goalIndex}`} style={[styles.goalText, { color: colors.text }]}>
+              {goal}
+            </Text>
+          ))}
+        </View>
+      ) : null}
+
+      {Array.isArray(quest?.tasks) && quest.tasks.length ? (
+        <View style={styles.infoSection}>
+          <Text style={[styles.infoLabel, { color: colors.text }]}>Tasks</Text>
+          <QuestStageList
+            stages={quest.tasks}
+            label={quest.stageLabel || 'Task'}
+            quest={quest}
+            colors={colors}
+            makeRewardEntries={makeRewardEntries}
+            onLogStage={onLogStage}
+          />
+        </View>
+      ) : null}
+
+      {tierSummary ? (
+        <View style={styles.infoSection}>
+          <Text style={[styles.stageSummaryText, { color: colors.text }]}>
+            {`Tier progress (${tierSummary})`}
+          </Text>
+        </View>
+      ) : null}
+
+      {milestoneSummary ? (
+        <View style={styles.infoSection}>
+          <Text style={[styles.stageSummaryText, { color: colors.text }]}>
+            {`Milestone progress (${milestoneSummary})`}
+          </Text>
+        </View>
+      ) : null}
+
+      {showTaskStages ? (
+        <View style={styles.infoSection}>
+          <Text style={[styles.infoLabel, { color: colors.text }]}>
+            {quest?.stageLabel ? `${quest.stageLabel}s` : 'Steps'}
+          </Text>
+          <QuestStageList
+            stages={quest.steps}
+            label={quest.stageLabel || 'Step'}
+            quest={quest}
+            colors={colors}
+            makeRewardEntries={makeRewardEntries}
+            onLogStage={onLogStage}
+            sequential
+          />
+        </View>
+      ) : null}
+
+      {quest?.trigger
+        ? renderMetaRow('flag-outline', 'Trigger', quest.trigger, `${quest?.id}-trigger`)
+        : null}
+      {quest?.duration
+        ? renderMetaRow('clock-time-four-outline', 'Duration', quest.duration, `${quest?.id}-duration`)
+        : null}
+      {timeRemainingLabel
+        ? renderMetaRow('timer-sand', 'Time left', timeRemainingLabel, `${quest?.id}-remaining`)
+        : null}
+      {quest?.lock ? renderMetaRow('lock-outline', 'Lock', quest.lock, `${quest?.id}-lock`) : null}
+      {quest?.requires
+        ? renderMetaRow('link-variant', 'Requires', quest.requires, `${quest?.id}-requires`)
+        : null}
+
+      {trackable ? (
+        <>
+          <View style={styles.progressSection}>
+            <View style={[styles.progressTrack, { backgroundColor: colors.chipBg }]}>
+              <LinearGradient
+                colors={[colors.sky, colors.emerald]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={[styles.progressFill, { width: `${percent}%` }]}
+              />
+            </View>
+            <Text style={[styles.progressLabel, { color: 'rgba(148,163,184,.95)' }]}>
+              {progress} / {goalValue}
+            </Text>
+          </View>
+          <TouchableOpacity
+            onPress={() => onClaim?.(quest)}
+            disabled={!claimable}
+            activeOpacity={0.85}
+            style={[
+              styles.claimButton,
+              {
+                borderColor: colors.surfaceBorder,
+                backgroundColor: claimable ? 'transparent' : colors.chipBg,
+              },
+            ]}
+          >
+            {claimable ? (
+              <LinearGradient
+                colors={[colors.sky, colors.emerald]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={[StyleSheet.absoluteFillObject, styles.claimGradient]}
+                pointerEvents="none"
+              />
+            ) : null}
+            <Text style={[styles.claimText, { color: claimable ? '#0f172a' : 'rgba(148,163,184,.95)' }]}>
+              {claimed ? 'Claimed' : 'Claim'}
+            </Text>
+          </TouchableOpacity>
+        </>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: 20,
+    padding: 20,
+    gap: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  titleGroup: {
+    flex: 1,
+    gap: 4,
+  },
+  title: {
+    fontFamily: 'SpaceGrotesk-Bold',
+    fontSize: 17,
+  },
+  subtitle: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 13,
+  },
+  rewardMeta: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  rewardPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    borderRadius: 999,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    backgroundColor: 'rgba(15,23,42,0.05)',
+  },
+  rewardText: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 12,
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+  },
+  actionText: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 13,
+  },
+  infoSection: {
+    gap: 10,
+  },
+  infoLabel: {
+    fontFamily: 'SpaceGrotesk-Bold',
+    fontSize: 13,
+  },
+  bonusList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  bonusPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderRadius: 999,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+  },
+  bonusText: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 12,
+  },
+  goalText: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 14,
+  },
+  stageSummaryText: {
+    fontFamily: 'SpaceGrotesk-Bold',
+    fontSize: 13,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  metaLabel: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 12,
+  },
+  metaValue: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 13,
+  },
+  rewardMetaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  progressSection: {
+    gap: 8,
+  },
+  progressTrack: {
+    borderRadius: 999,
+    overflow: 'hidden',
+    height: 8,
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 999,
+  },
+  progressLabel: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 12,
+    textAlign: 'center',
+  },
+  claimButton: {
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingVertical: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  claimGradient: {
+    borderRadius: 999,
+  },
+  claimText: {
+    fontFamily: 'SpaceGrotesk-Bold',
+    fontSize: 14,
+  },
+});
+
+export const QuestCard = memo(QuestCardComponent);
+export default QuestCard;

--- a/src/features/quests/components/QuestStageList.js
+++ b/src/features/quests/components/QuestStageList.js
@@ -1,0 +1,207 @@
+import { memo, useMemo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { hexToRgba } from '../../../utils/color';
+
+const QuestStageListComponent = ({
+  stages,
+  label,
+  quest,
+  colors,
+  makeRewardEntries,
+  onLogStage,
+  sequential = false,
+}) => {
+  const rewardEntriesFor = makeRewardEntries || (() => []);
+
+  const visibleStages = useMemo(() => {
+    if (!Array.isArray(stages) || !stages.length) {
+      return [];
+    }
+
+    if (!sequential) {
+      return stages.map((stage, index) => ({ stage, stageIndex: index }));
+    }
+
+    const entries = [];
+    let allowNext = true;
+
+    stages.forEach((stage, index) => {
+      if (stage?.completed === true) {
+        entries.push({ stage, stageIndex: index });
+        return;
+      }
+
+      if (allowNext) {
+        entries.push({ stage, stageIndex: index });
+        allowNext = false;
+      }
+    });
+
+    return entries;
+  }, [stages, sequential]);
+
+  if (!visibleStages.length) {
+    return null;
+  }
+
+  const questId = quest?.id;
+
+  return (
+    <View style={styles.container}>
+      {visibleStages.map(({ stage, stageIndex }) => {
+        const stageRewards = rewardEntriesFor(stage?.reward);
+        const isClaimed = stage?.claimed === true;
+        const isCompleted = stage?.completed === true;
+        const isReady = !isClaimed && isCompleted;
+        const showProgress =
+          typeof stage?.progress === 'number' &&
+          typeof stage?.goalValue === 'number' &&
+          stage.goalValue > 0;
+        const progressValue = showProgress
+          ? `${Math.min(stage.progress, stage.goalValue)} / ${stage.goalValue}`
+          : null;
+        const backgroundColor = isClaimed
+          ? hexToRgba(colors.emerald, 0.12)
+          : isReady
+          ? hexToRgba(colors.amber, 0.12)
+          : colors.chipBg;
+        const borderColor = isClaimed
+          ? hexToRgba(colors.emerald, 0.45)
+          : isReady
+          ? hexToRgba(colors.amber, 0.45)
+          : colors.surfaceBorder;
+        const statusColor = isClaimed ? colors.emerald : isReady ? colors.amber : null;
+
+        return (
+          <View
+            key={`${questId || label}-${stageIndex}`}
+            style={[styles.stageRow, { backgroundColor, borderColor }]}
+          >
+            <View style={styles.stageHeader}>
+              <View style={styles.stageTitleRow}>
+                <Text style={[styles.stageTitle, { color: colors.text }]}>
+                  {`${label} ${stageIndex + 1}`}
+                </Text>
+                {statusColor ? (
+                  <MaterialCommunityIcons
+                    name="check-circle"
+                    size={16}
+                    color={statusColor}
+                    style={styles.stageStatusIcon}
+                  />
+                ) : null}
+              </View>
+              {stageRewards.length ? (
+                <View style={styles.rewardMeta}>
+                  {stageRewards.map((entry, rewardIndex) => (
+                    <View key={`${questId || label}-${stageIndex}-reward-${rewardIndex}`} style={styles.rewardPill}>
+                      <MaterialCommunityIcons name={entry.icon} size={14} color={entry.color} />
+                      <Text style={[styles.rewardText, { color: colors.text }]}>{entry.label}</Text>
+                    </View>
+                  ))}
+                </View>
+              ) : null}
+            </View>
+            {stage?.goal ? (
+              <Text style={[styles.stageGoal, { color: hexToRgba(colors.text, 0.75) }]}>{stage.goal}</Text>
+            ) : null}
+            {progressValue ? (
+              <Text style={[styles.stageProgress, { color: hexToRgba(colors.text, 0.68) }]}>
+                {progressValue}
+              </Text>
+            ) : null}
+            {stage?.manualKey ? (
+              <TouchableOpacity
+                onPress={() =>
+                  onLogStage?.(stage.manualKey, {
+                    questId,
+                    stageId: stage.id || stage.index,
+                  })
+                }
+                style={[styles.stageButton, { borderColor: colors.surfaceBorder, backgroundColor: colors.chipBg }]}
+                activeOpacity={0.85}
+              >
+                <MaterialCommunityIcons name="plus-circle-outline" size={14} color={colors.sky} />
+                <Text style={[styles.stageButtonText, { color: colors.text }]}>Log progress</Text>
+              </TouchableOpacity>
+            ) : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  stageRow: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+  },
+  stageHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+  },
+  stageTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  stageTitle: {
+    fontFamily: 'SpaceGrotesk-Bold',
+    fontSize: 15,
+  },
+  stageStatusIcon: {
+    marginLeft: 2,
+  },
+  rewardMeta: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  rewardPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    borderRadius: 999,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    backgroundColor: 'rgba(15,23,42,0.05)',
+  },
+  rewardText: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 12,
+  },
+  stageGoal: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 13,
+  },
+  stageProgress: {
+    fontFamily: 'SpaceGrotesk-Regular',
+    fontSize: 12,
+  },
+  stageButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+  },
+  stageButtonText: {
+    fontFamily: 'SpaceGrotesk-Medium',
+    fontSize: 13,
+  },
+});
+
+export const QuestStageList = memo(QuestStageListComponent);
+export default QuestStageList;

--- a/src/features/quests/components/QuestTabs.js
+++ b/src/features/quests/components/QuestTabs.js
@@ -1,0 +1,102 @@
+import { memo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+const QuestTabsComponent = ({ tabs, activeTab, onSelect, colors, badgeShadow, badgeCounts = {} }) => {
+  if (!Array.isArray(tabs) || !tabs.length) {
+    return null;
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface, borderColor: colors.surfaceBorder }]}>
+      {tabs.map((tab) => {
+        const isActive = tab.key === activeTab;
+        const badge = badgeCounts[tab.key] || 0;
+        return (
+          <TouchableOpacity
+            key={tab.key}
+            onPress={() => onSelect?.(tab.key)}
+            activeOpacity={0.85}
+            style={[styles.tabButton, { borderColor: colors.surfaceBorder, backgroundColor: colors.surface }]}
+          >
+            {isActive ? (
+              <LinearGradient
+                colors={[colors.sky, colors.emerald]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={[StyleSheet.absoluteFillObject, styles.tabGradient]}
+                pointerEvents="none"
+              />
+            ) : null}
+            <View style={styles.tabContent}>
+              <MaterialCommunityIcons
+                name={tab.icon}
+                size={16}
+                color={isActive ? '#0f172a' : colors.text}
+                style={styles.tabIcon}
+              />
+              <Text style={[styles.tabLabel, { color: isActive ? '#0f172a' : colors.text }]}>{tab.key}</Text>
+            </View>
+            {badge > 0 ? (
+              <View style={[styles.badge, badgeShadow]}>
+                <Text style={styles.badgeText}>{badge}</Text>
+              </View>
+            ) : null}
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    gap: 8,
+    padding: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    marginBottom: 16,
+  },
+  tabButton: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  tabGradient: {
+    borderRadius: 12,
+  },
+  tabContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 10,
+  },
+  tabIcon: {
+    marginRight: 2,
+  },
+  tabLabel: {
+    fontFamily: 'SpaceGrotesk-Bold',
+    fontSize: 13,
+  },
+  badge: {
+    position: 'absolute',
+    top: 6,
+    right: 8,
+    backgroundColor: '#f43f5e',
+    borderRadius: 999,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  badgeText: {
+    color: '#fff',
+    fontFamily: 'SpaceGrotesk-Bold',
+    fontSize: 11,
+  },
+});
+
+export const QuestTabs = memo(QuestTabsComponent);
+export default QuestTabs;

--- a/src/features/quests/hooks/useQuestBoard.js
+++ b/src/features/quests/hooks/useQuestBoard.js
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  buildQuestTabs,
+  computeQuestMetrics,
+  computeEventProgressMap,
+  evaluateEventStates,
+  composeQuestClaimKey,
+} from '../utils/questProcessing';
+import { QUESTS } from '../data/questCatalog';
+
+const collectStageIds = (quest) => {
+  if (!quest?.id) {
+    return [];
+  }
+
+  const stageIds = [];
+
+  if (Array.isArray(quest?.tiers)) {
+    quest.tiers.forEach((tier, index) => {
+      const tierId = tier?.id || `${quest.id}-tier-${index}`;
+      if (tierId) {
+        stageIds.push(tierId);
+      }
+    });
+  }
+
+  if (Array.isArray(quest?.steps)) {
+    quest.steps.forEach((step, index) => {
+      const stepId = step?.id || `${quest.id}-step-${index}`;
+      if (stepId) {
+        stageIds.push(stepId);
+      }
+    });
+  }
+
+  return stageIds;
+};
+
+export const useQuestBoard = ({
+  baseQuests = QUESTS,
+  applications,
+  manualLogs,
+  currentTime,
+  claimedQuests,
+  setClaimedQuests,
+  eventStates,
+  setEventStates,
+  eventsReactivatedRef,
+}) => {
+  const previousEventStatesRef = useRef({});
+
+  const eventDefinitions = useMemo(
+    () =>
+      Array.isArray(baseQuests?.Events)
+        ? baseQuests.Events.filter((quest) => quest?.type === 'event')
+        : [],
+    [baseQuests],
+  );
+
+  useEffect(() => {
+    if (!eventDefinitions.length || typeof setEventStates !== 'function') {
+      return;
+    }
+
+    setEventStates((prev) =>
+      evaluateEventStates({
+        definitions: eventDefinitions,
+        previousStates: prev,
+        manualLogs,
+        applications,
+        now: currentTime,
+      }),
+    );
+  }, [
+    eventDefinitions,
+    setEventStates,
+    manualLogs,
+    applications,
+    currentTime,
+  ]);
+
+  const eventStageIds = useMemo(() => {
+    return eventDefinitions.reduce((acc, quest) => {
+      if (quest?.id) {
+        acc[quest.id] = collectStageIds(quest);
+      }
+      return acc;
+    }, {});
+  }, [eventDefinitions]);
+
+  const questMetrics = useMemo(
+    () => computeQuestMetrics({ applications, manualLogs, now: currentTime }),
+    [applications, manualLogs, currentTime],
+  );
+
+  const eventProgress = useMemo(
+    () =>
+      computeEventProgressMap({
+        events: eventStates,
+        applications,
+        manualLogs,
+        now: currentTime,
+      }),
+    [eventStates, applications, manualLogs, currentTime],
+  );
+
+  const { questsByTab, unclaimedByTab } = useMemo(
+    () =>
+      buildQuestTabs({
+        base: baseQuests,
+        metrics: questMetrics,
+        claimed: claimedQuests,
+        events: eventStates,
+        eventProgress,
+      }),
+    [baseQuests, questMetrics, claimedQuests, eventStates, eventProgress],
+  );
+
+  useEffect(() => {
+    if (typeof setClaimedQuests !== 'function') {
+      return;
+    }
+
+    const prevStates = previousEventStatesRef.current || {};
+    const currentStates = eventStates && typeof eventStates === 'object' ? eventStates : {};
+    previousEventStatesRef.current = currentStates;
+
+    const cleanupTargets = [];
+    const reactivatedEventIds = [];
+
+    Object.entries(currentStates).forEach(([eventId, state]) => {
+      if (!state || state.active !== true || !Number.isFinite(state.triggeredAt)) {
+        return;
+      }
+      const prevState = prevStates[eventId];
+      const prevTrigger = Number.isFinite(prevState?.triggeredAt) ? prevState.triggeredAt : undefined;
+      if (prevTrigger == null || prevTrigger === state.triggeredAt) {
+        return;
+      }
+      const stageIds = eventStageIds[eventId] || [];
+      cleanupTargets.push({
+        ids: [eventId, ...stageIds],
+        triggeredAt: prevTrigger,
+      });
+      reactivatedEventIds.push(eventId);
+    });
+
+    if (cleanupTargets.length) {
+      setClaimedQuests((currentSet) => {
+        if (!(currentSet instanceof Set) || currentSet.size === 0) {
+          return currentSet;
+        }
+        let mutated = false;
+        const nextSet = new Set(currentSet);
+        cleanupTargets.forEach(({ ids, triggeredAt }) => {
+          ids.forEach((id) => {
+            if (!id) {
+              return;
+            }
+            const compositeKey = composeQuestClaimKey(id, triggeredAt);
+            if (compositeKey && nextSet.delete(compositeKey)) {
+              mutated = true;
+            }
+            if (nextSet.delete(id)) {
+              mutated = true;
+            }
+          });
+        });
+        return mutated ? nextSet : currentSet;
+      });
+    }
+
+    if (reactivatedEventIds.length && eventsReactivatedRef?.current) {
+      eventsReactivatedRef.current(reactivatedEventIds);
+    }
+  }, [eventStates, eventStageIds, setClaimedQuests, eventsReactivatedRef]);
+
+  return {
+    questMetrics,
+    eventProgress,
+    questsByTab,
+    unclaimedByTab,
+    eventDefinitions,
+    eventStageIds,
+  };
+};

--- a/src/features/quests/hooks/useQuestNotifications.js
+++ b/src/features/quests/hooks/useQuestNotifications.js
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const ensureObject = (value) => (value && typeof value === 'object' ? value : {});
+
+export const useQuestNotifications = ({
+  eventStates,
+  questsByTab,
+  questTab,
+  unclaimedByTab,
+  onManualLog,
+  eventSeenRef,
+  eventsReactivatedRef,
+}) => {
+  const [eventNotifications, setEventNotifications] = useState(() => ({}));
+  const previousStatesRef = useRef({});
+
+  useEffect(() => {
+    const prevStates = previousStatesRef.current || {};
+    const currentStates = ensureObject(eventStates);
+    previousStatesRef.current = currentStates;
+
+    setEventNotifications((currentNotifications) => {
+      const safeCurrent = ensureObject(currentNotifications);
+      let nextNotifications = safeCurrent;
+      let changed = false;
+
+      Object.entries(safeCurrent).forEach(([eventId, triggerAt]) => {
+        const state = currentStates[eventId];
+        if (
+          !state ||
+          state.active !== true ||
+          !Number.isFinite(state.triggeredAt) ||
+          state.triggeredAt !== triggerAt
+        ) {
+          if (!changed) {
+            nextNotifications = { ...nextNotifications };
+            changed = true;
+          }
+          delete nextNotifications[eventId];
+        }
+      });
+
+      Object.entries(currentStates).forEach(([eventId, state]) => {
+        if (!state || state.active !== true || !Number.isFinite(state.triggeredAt)) {
+          return;
+        }
+        const prevState = prevStates[eventId];
+        const prevActive = prevState?.active === true && Number.isFinite(prevState?.triggeredAt);
+        const seenTrigger = eventSeenRef?.current?.get?.(eventId);
+        const isNewTrigger = !prevActive || prevState.triggeredAt !== state.triggeredAt;
+        const alreadySeen = seenTrigger === state.triggeredAt;
+        const alreadyNotified = nextNotifications[eventId] === state.triggeredAt;
+
+        if (isNewTrigger && !alreadySeen && !alreadyNotified) {
+          if (!changed) {
+            nextNotifications = { ...nextNotifications };
+            changed = true;
+          }
+          nextNotifications[eventId] = state.triggeredAt;
+        }
+      });
+
+      return changed ? nextNotifications : safeCurrent;
+    });
+  }, [eventStates, eventSeenRef]);
+
+  useEffect(() => {
+    if (questTab !== 'Events') {
+      return;
+    }
+
+    setEventNotifications((current) => {
+      const safeCurrent = ensureObject(current);
+      const entries = Object.entries(safeCurrent);
+      if (!entries.length) {
+        return current;
+      }
+      const seenMap = eventSeenRef?.current;
+      entries.forEach(([eventId, triggeredAt]) => {
+        if (Number.isFinite(triggeredAt)) {
+          seenMap?.set?.(eventId, triggeredAt);
+        }
+      });
+      return {};
+    });
+  }, [questTab, eventNotifications, eventSeenRef]);
+
+  const eventNotificationIds = useMemo(
+    () => Object.keys(ensureObject(eventNotifications)),
+    [eventNotifications],
+  );
+
+  const eventNotificationCount = eventNotificationIds.length;
+
+  const eventClaimableIds = useMemo(() => {
+    const eventsList = questsByTab?.Events || [];
+    const ids = new Set();
+    eventsList.forEach((quest) => {
+      if (quest?.type === 'event' && quest.claimable) {
+        ids.add(quest.id);
+      }
+    });
+    return ids;
+  }, [questsByTab]);
+
+  const unseenClaimableEventCount = useMemo(
+    () =>
+      eventNotificationIds.reduce(
+        (count, id) => (eventClaimableIds.has(id) ? count + 1 : count),
+        0,
+      ),
+    [eventNotificationIds, eventClaimableIds],
+  );
+
+  const additionalEventNotifications = useMemo(
+    () => Math.max(0, eventNotificationCount - unseenClaimableEventCount),
+    [eventNotificationCount, unseenClaimableEventCount],
+  );
+
+  const eventTabBadgeCount = useMemo(
+    () => (unclaimedByTab?.Events || 0) + additionalEventNotifications,
+    [unclaimedByTab, additionalEventNotifications],
+  );
+
+  const handleQuestAction = useCallback(
+    (action, quest) => {
+      if (!action) {
+        return;
+      }
+      if (action.type === 'log' && action.key) {
+        onManualLog?.(action.key, { questId: quest?.id, actionKey: action.key });
+      }
+    },
+    [onManualLog],
+  );
+
+  const getStageProgressSummary = useCallback((stages) => {
+    if (!Array.isArray(stages) || !stages.length) {
+      return null;
+    }
+    const total = stages.length;
+    const completed = stages.reduce((count, stage) => {
+      if (stage?.claimed === true) {
+        return count + 1;
+      }
+      if (stage?.claimed === false) {
+        return count;
+      }
+      return stage?.completed ? count + 1 : count;
+    }, 0);
+    const current = Math.min(completed + 1, total);
+    return `${current}/${total}`;
+  }, []);
+
+  const handleEventsReactivated = useCallback(
+    (eventIds = []) => {
+      if (!Array.isArray(eventIds) || !eventIds.length) {
+        return;
+      }
+      const seenMap = eventSeenRef?.current;
+      if (!seenMap || typeof seenMap.delete !== 'function') {
+        return;
+      }
+      eventIds.forEach((eventId) => {
+        seenMap.delete(eventId);
+      });
+    },
+    [eventSeenRef],
+  );
+
+  if (eventsReactivatedRef) {
+    eventsReactivatedRef.current = handleEventsReactivated;
+  }
+
+  return {
+    eventTabBadgeCount,
+    handleQuestAction,
+    getStageProgressSummary,
+  };
+};


### PR DESCRIPTION
## Summary
- add quest board hooks and quest notification helper to centralize state derivation
- introduce QuestTabs, QuestCard, and QuestStageList components to modularize quests UI
- refactor App.js to consume new hooks/components while preserving quest state handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d792796c1c832ca1f083bcbe24eeba