### PR TITLE
Remove stale quest event state effect from App

### DIFF
--- a/App.js
+++ b/App.js
@@ -1776,21 +1776,6 @@ export default function App() {
     return () => clearInterval(interval);
   }, []);
 
-  useEffect(() => {
-    if (!EVENT_DEFINITIONS.length) {
-      return;
-    }
-    setEventStates((prev) =>
-      evaluateEventStates({
-        definitions: EVENT_DEFINITIONS,
-        previousStates: prev,
-        manualLogs,
-        applications,
-        now: currentTime,
-      }),
-    );
-  }, [manualLogs, applications, currentTime]);
-
   const pushEffectWarnings = useCallback(
     (messages = []) => {
       if (!Array.isArray(messages) || messages.length === 0) {


### PR DESCRIPTION
## Summary
- remove the obsolete event state persistence effect from App now that useQuestBoard handles the logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d797f9d238832ca87227591cf59957